### PR TITLE
Add "LTE only" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Official Site > [https://grapheneos.org](https://grapheneos.org)
 
 ## ⚙️ Settings
 #### Network & internet
-* Settings > Network & internet > Internet > Carrier Settings ⚙️ > `Allow 2G` ❌
+* Settings > Network & internet > Internet > Carrier Settings ⚙️ > Preferred network type > `LTE only` ✅
 * Settings > Network & internet > Internet > *Select your Wi-Fi* ⚙️ > *select pen icon* > Advanced options > Privacy > `Use per-connection randomized MAC (default)` ✅
 * Settings > Network & internet > Private DNS > Private DNS provider hostname: `dns.quad9.net` ✅
 * Settings > Network & internet > Internet connectivity checks > `Disabled` ❌

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Official Site > [https://grapheneos.org](https://grapheneos.org)
 
 ## ⚙️ Settings
 #### Network & internet
-* Settings > Network & internet > Internet > Carrier Settings ⚙️ > Preferred network type > `LTE only` ✅
+* Settings > Network & internet > Internet > Carrier Settings ⚙️ > Preferred network type > `LTE only` ✅ (if you do not need 5G)
+* Settings > Network & internet > Internet > Carrier Settings ⚙️ > `Allow 2G` ❌ (if option exists)
 * Settings > Network & internet > Internet > *Select your Wi-Fi* ⚙️ > *select pen icon* > Advanced options > Privacy > `Use per-connection randomized MAC (default)` ✅
 * Settings > Network & internet > Private DNS > Private DNS provider hostname: `dns.quad9.net` ✅
 * Settings > Network & internet > Internet connectivity checks > `Disabled` ❌


### PR DESCRIPTION
* Functionally this is equivalent, as 2G/3G cellular reception will be disabled
* Source, GOS Usage [guide](https://grapheneos.org/usage#lte-only-mode)
* Additional source, [video](https://www.youtube.com/watch?v=GLJyD9MJgIQ) from the Privacy Wayfinder (May 2023)
* Accidentally closed PR #2