### PR TITLE
Push minor updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@
 
 ### App Stores
 - [F-Droid](https://f-droid.org/) - The app store that respects freedom and privacy
-- [accrescent](https://github.com/accrescent/accrescent/releases/latest) - A novel Android app store focused on security, privacy, and usability
+- [Accrescent](https://github.com/accrescent/accrescent/releases/latest) - A novel Android app store focused on security, privacy, and usability
 - [Aurora Store](https://f-droid.org/packages/com.aurora.store/) - An open-source alternative to Google Play Store with privacy and modern design
 
 ### F-Droid Apps
 - Web Browser
   - [Mull](https://f-droid.org/packages/us.spotco.fennec_dos/) - Privacy oriented web browser (FF Based)
-  - [cromite](https://github.com/uazo/cromite/releases/latest) - Cromite a Bromite fork with ad blocking and privacy enhancements; take back your browser! 
+  - [Cromite](https://github.com/uazo/cromite/releases/latest) - Cromite a Bromite fork with ad blocking and privacy enhancements; take back your browser! 
 - Navigation
   - [Organic Maps](https://f-droid.org/packages/app.organicmaps/) - Open-source, community-driven maps for travelers, tourists, cyclists & hikers
   - [OsmAnd~](https://f-droid.org/packages/net.osmand.plus/) - Global Mobile Map Viewing & Navigation for Offline and Online OSM Maps
@@ -200,7 +200,7 @@
   - [AntennaPod](https://f-droid.org/packages/de.danoeh.antennapod/) - Easy-to-use, flexible and open-source podcast manager and player
   - [Podverse](https://f-droid.org/packages/com.podverse.fdroid/) - Podcast app with clips, video, livestreams, playlists, profiles, and cross-platform
 - Social Media
-  - [Squawker](https://f-droid.org/en/packages/org.ca.squawker/) - An open-source anonymous Twitter/X client
+  - [Squawker](https://f-droid.org/en/packages/org.ca.squawker/) - An open-source Twitter/X client
   - [Infinity for Reddit](https://f-droid.org/en/packages/ml.docilealligator.infinityforreddit/) - A beautiful, feature-rich Reddit client.
   - [Mastodon](https://f-droid.org/packages/org.joinmastodon.android/) - Decentralized social network
   - [Shitter](https://f-droid.org/en/packages/org.nuclearfog.twidda/) - A lightweight Mastodon client focused on privacy and low data consumption
@@ -221,7 +221,7 @@
   - [Mullvad VPN](https://f-droid.org/packages/net.mullvad.mullvadvpn/) - Protect your online privacy with a fast, trustworthy, and easy-to-use VPN.
   - [IVPN](https://f-droid.org/packages/net.ivpn.client/) - Privacy focused VPN service with WireGuard
   - [Calyx VPN](https://f-droid.org/packages/org.calyxinstitute.vpn/) - Free VPN Service offered by The Calyx Institute
-  - [ProtonVPN](https://f-droid.org/packages/ch.protonvpn.android/) - Free Swiss VPN with advanced security and privacy features.
+  - [Proton VPN](https://f-droid.org/packages/ch.protonvpn.android/) - Free Swiss VPN with advanced security and privacy features.
 - App Control & Container/Isolator
   - [NetGuard](https://f-droid.org/packages/eu.faircode.netguard/) - A simple way to block access to the internet per application
   - [Insular](https://f-droid.org/packages/com.oasisfeng.island.fdroid/) - Isolate your Big Brother apps
@@ -234,6 +234,7 @@
   - [Lawnchair](https://f-droid.org/en/packages/ch.deletescape.lawnchair.plah/) - Pixel Launcher features plus customizability
   - [Public IP](https://f-droid.org/en/packages/net.guildem.publicip/) - App and Widget allowing user to find its current public IP address
   - [Catima](https://f-droid.org/packages/me.hackerchick.catima/) - Catima, a Loyalty Card & Ticket Manager for Android
+  - [Feeder](https://github.com/spacecowboy/Feeder) - Android RSS reader app
 
 ### Aurora Store Apps
 - Magic Earth


### PR DESCRIPTION
* Keep capitalization consistent for Cromite and Accrescent
    * Also "Proton VPN" is Proton Tech's current stylization
* Squawker can no longer use anonymous accounts to view Twitter accounts, after Nitter was effectively cut off from anonymous account creation earlier in 2024
    * See j-fbriere/squawker#180 for more info
    * You can set Squawker to view without logging into a Twitter account, but that's about it
* Add [Feeder](https://github.com/spacecowboy/Feeder), a news aggregator app for Android and is [recommended](https://www.privacyguides.org/en/news-aggregators/#feeder) by Privacy Guides
    * It uses Material You and is updated regularly